### PR TITLE
Fixed #819: Volume steps aren't working correctly

### DIFF
--- a/src/audio_service.c
+++ b/src/audio_service.c
@@ -38,7 +38,7 @@
 
 #define SAMPLE_PATH		"/usr/share/systemsounds"
 
-#define VOLUME_STEP		10
+#define VOLUME_STEP		11
 
 extern GMainLoop *event_loop;
 static GSList *sample_list = NULL;
@@ -373,7 +373,9 @@ static bool volume_up_cb(LSHandle *handle, LSMessage *message, void *user_data)
 		return true;
 	}
 
-	normalized_volume = (service->volume / 10) * 10;
+	normalized_volume = (service->volume / VOLUME_STEP) * VOLUME_STEP % 100;
+	if (normalized_volume >= 88) /* because VOLUME_STEP is 11, this adjustment is needed to get from 88 to 100 */
+		++normalized_volume;
 	if (normalized_volume == 100)
 		goto done;
 
@@ -401,7 +403,7 @@ static bool volume_down_cb(LSHandle *handle, LSMessage *message, void *user_data
 		return true;
 	}
 
-	normalized_volume = (service->volume / 10) * 10;
+	normalized_volume = (service->volume / VOLUME_STEP) * VOLUME_STEP % 100;
 	if (normalized_volume == 0)
 		goto done;
 

--- a/src/audio_service.c
+++ b/src/audio_service.c
@@ -373,11 +373,12 @@ static bool volume_up_cb(LSHandle *handle, LSMessage *message, void *user_data)
 		return true;
 	}
 
-	normalized_volume = (service->volume / VOLUME_STEP) * VOLUME_STEP % 100;
-	if (normalized_volume >= 88) /* because VOLUME_STEP is 11, this adjustment is needed to get from 88 to 100 */
-		++normalized_volume;
-	if (normalized_volume == 100)
+	normalized_volume = (service->volume / VOLUME_STEP) * VOLUME_STEP;
+	if (normalized_volume >= 99)
 		goto done;
+	else if (normalized_volume >= 88) /* because VOLUME_STEP is 11, this adjustment is needed to get from 88 to 100 */
+		++normalized_volume;
+
 
 	req = luna_service_req_data_new(handle, message);
 	req->user_data = service;
@@ -403,8 +404,10 @@ static bool volume_down_cb(LSHandle *handle, LSMessage *message, void *user_data
 		return true;
 	}
 
-	normalized_volume = (service->volume / VOLUME_STEP) * VOLUME_STEP % 100;
-	if (normalized_volume == 0)
+	normalized_volume = ((service->volume + VOLUME_STEP - 1) / VOLUME_STEP) * VOLUME_STEP;
+	if (normalized_volume >= 100) /* If service->volume is 100, we'd be at 110. Adjust */
+		normalized_volume = 99;
+	else if (normalized_volume == 0)
 		goto done;
 
 	req = luna_service_req_data_new(handle, message);


### PR DESCRIPTION
From [http://issues.webos-ports.org/issues/819](http://issues.webos-ports.org/issues/819). Updated VOLUME_STEP to 11 and adjusted uses in `volume_up_cb()` and `volume_down_cb()` accordingly.