### PR TITLE
audioservice: also accept "Voice Call" as voice call profile name

### DIFF
--- a/src/audioservice.cpp
+++ b/src/audioservice.cpp
@@ -689,7 +689,7 @@ void AudioService::cm_cardinfo_cb(pa_context *context, const pa_card_info *info,
     for (i = 0; i < info->n_profiles; i++) {
         if (!highest || info->profiles[i].priority > highest->priority)
             highest = &info->profiles[i];
-        if (!strcmp(info->profiles[i].name, "voicecall"))
+        if (!strcasecmp(info->profiles[i].name, "voicecall") || !strcasecmp(info->profiles[i].name, "voice call"))
             voice_call = &info->profiles[i];
     }
 


### PR DESCRIPTION
This lets us use more variations of the UCM profile name

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>