### PR TITLE
Give access to our Settings app as well

### DIFF
--- a/files/sysbus/org.webosports.service.audio.role.json
+++ b/files/sysbus/org.webosports.service.audio.role.json
@@ -58,7 +58,8 @@
                         "com.webos.media",
                         "com.webos.keys",
                         "org.webosports.luna",
-                        "org.webosports.app.phone-*"]
+                        "org.webosports.app.phone-*",
+                        "org.webosports.app.settings-*"]
         },
         {
             "service":"com.palm.audio",
@@ -80,7 +81,9 @@
                         "com.webos.settingsservice",
                         "com.webos.media",
                         "com.webos.keys",
-                        "org.webosports.luna"]
+                        "org.webosports.luna",
+                        "org.webosports.app.phone-*",
+                        "org.webosports.app.settings-*"]
         }
     ]
 }


### PR DESCRIPTION
Otherwise we get:

2020-06-09T15:58:53.810889Z [33.202671943] user.err ls-hubd [] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"org.webosports.app.settings-1007","SRC_APP_ID":"org.webosports.service.audio","EXE":"/usr/sbin/audio-service","PID":376} "org.webosports.service.audio" does not have sufficient outbound permissions to communicate with "org.webosports.app.settings-1007" (cmdline: /usr/sbin/audio-service)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>