### PR TITLE
audio-service: Add groups file

### DIFF
--- a/files/sysbus/org.webosports.service.audio.groups.json
+++ b/files/sysbus/org.webosports.service.audio.groups.json
@@ -1,0 +1,5 @@
+{
+ "allowedNames": ["org.webosports.service.audio", "com.palm.audio", "com.webos.audio", "com.webos.service.audio"],
+ "audio.operation": ["dev"],
+ "audio.management": ["oem"]
+}


### PR DESCRIPTION
Fixes warning for LS2 validation.

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   audio.management
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   audio.operation