### PR TITLE
audio-service: Update permissions

### DIFF
--- a/files/sysbus/org.webosports.service.audio.perm.json
+++ b/files/sysbus/org.webosports.service.audio.perm.json
@@ -1,43 +1,38 @@
 {
     "com.webos.audio": [
-        "devices",
-        "system",
-        "settings",
-        "media",
-        "tv.services",
-        "applications.query"
+        "settings.query",
+        "settings.management",
+        "bluetooth.query",
+        "physicaldevice.query",
+        "audiooutput.management",
+        "telephony.management",
+        "telephony.query"
     ],
     "com.webos.service.audio": [
-        "devices",
-        "services",
-        "system",
-        "telephony",
-        "settings",
-        "media",
-        "tv.services",
-        "applications.query",
-        "audiooutputd"
+        "settings.query",
+        "settings.management",
+        "bluetooth.query",
+        "physicaldevice.query",
+        "audiooutput.management",
+        "telephony.management",
+        "telephony.query"
     ],
     "com.palm.audio": [
-        "devices",
-        "services",
-        "system",
-        "telephony",
-        "settings",
-        "media",
-        "tv.services",
-        "applications.query",
-        "audiooutputd"
+        "settings.query",
+        "settings.management",
+        "bluetooth.query",
+        "physicaldevice.query",
+        "audiooutput.management",
+        "telephony.management",
+        "telephony.query"
     ],
     "org.webosports.service.audio": [
-        "devices",
-        "services",
-        "system",
-        "telephony",
-        "settings",
-        "media",
-        "tv.services",
-        "applications.query",
-        "audiooutputd"
+        "settings.query",
+        "settings.management",
+        "bluetooth.query",
+        "physicaldevice.query",
+        "audiooutput.management",
+        "telephony.management",
+        "telephony.query"
     ]
 }


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 2 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'applications.query' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'audiooutputd' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'devices' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'media' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'services' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'settings' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'system' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'tv.services' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.audio.perm.json